### PR TITLE
Don't spend CPU type on building and adding scaladocs to publish artifacts

### DIFF
--- a/src/main/scala/dotdata/sbt/SbtConfig.scala
+++ b/src/main/scala/dotdata/sbt/SbtConfig.scala
@@ -174,6 +174,9 @@ object SbtConfig extends AutoPlugin {
       if (publishingEnabled) {
         Seq(
           organization := "com.dotdata",
+          // Don't generate docs in production builds
+          sources in (Compile, doc) := Seq.empty,
+          publishArtifact in (Compile, packageDoc) := false,
           publishMavenStyle := true,
           publishTo := {
             // Repository internal caching


### PR DESCRIPTION
I think this makes sense, I can see the jenkins instances spending precious time generating these each time.