### PR TITLE
Turn back on publish maven style since it is a maven-style packages dir

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -26,7 +26,7 @@ version := {
   }
 }
 
-publishMavenStyle := false
+publishMavenStyle := true
 
 publishTo := Some("GitHub Package Registry" at "https://maven.pkg.github.com/ramencloud/sbt-config")
 credentials ++= {


### PR DESCRIPTION
the `.pom` file wasn't being created, reverting my previous change