### PR TITLE
Lenient warnings in some contexts

### DIFF
--- a/src/main/scala/dotdata/sbt/SbtConfigPlugin.scala
+++ b/src/main/scala/dotdata/sbt/SbtConfigPlugin.scala
@@ -120,19 +120,24 @@ object SbtConfigPlugin extends AutoPlugin {
     // Deprecations are not immediate and need a notice
     val fatalWarningsExceptDeprecation: Def.SettingsDefinition =
       Seq(Compile, Test).flatMap(inConfig(_) {
+
         compile := {
           val compiled = compile.value
-          val problems = compiled.readSourceInfos().getAllSourceInfos.asScala.flatMap {
-            case (_, info) =>
-              info.getReportedProblems
-          }
+          if (scalacOptions.value.contains("-Xfatal-warnings")) {
+            val problems = compiled.readSourceInfos().getAllSourceInfos.asScala.flatMap {
+              case (_, info) =>
+                info.getReportedProblems
+            }
 
-          val deprecationsOnly = problems.forall { problem =>
-            problem.message().contains("is deprecated")
-          }
+            val deprecationsOnly = problems.forall { problem =>
+              problem.message().contains("is deprecated")
+            }
 
-          if (!deprecationsOnly) sys.error("Fatal warnings: some warnings other than deprecations were found.")
-          compiled
+            if (!deprecationsOnly) sys.error("Fatal warnings: some warnings other than deprecations were found.")
+            compiled
+          } else {
+            compiled
+          }
         }
       })
 
@@ -151,8 +156,13 @@ object SbtConfigPlugin extends AutoPlugin {
     // Allow some behavior while interactively working on Scala code from the REPL
     private val scalacOptionsConsoleExclusions: Seq[String] = Seq(
       "-Xlint",
+      "-Xlint:_,-unused,-missing-interpolator",
+      "-unchecked",
       "-Xfatal-warnings",
-      "-Ywarn-unused-import"
+      "-Ywarn-unused-import",
+      "-Ywarn-value-discard",
+      "-Ywarn-dead-code",
+      "-Ywarn-unused:_,-explicits,-implicits",
     )
 
     private val scalacOptionsNotInTest: Seq[String] = Seq(


### PR DESCRIPTION
In particular:
 - Disable most warnings when using the REPL.
 - The custom feature which fails the build for warnings other than
   deprecation first checks if the `fatal-warnings` flag has been set.

In response to #23