### PR TITLE
Make the default testOptions to include IntegrationTest Configuration

### DIFF
--- a/src/main/scala/com/dotdata/sbt/SbtConfigPlugin.scala
+++ b/src/main/scala/com/dotdata/sbt/SbtConfigPlugin.scala
@@ -213,7 +213,7 @@ object SbtConfigPlugin extends AutoPlugin {
       //  - D: Show durations of each test
       //  - F: Show full stack traces
       //  - -u: Causes test results to be written to junit-style xml files in the named directory so CI can pick it up
-      Test / testOptions += Tests.Argument(TestFrameworks.ScalaTest, "-oDF", "-u", "target/test-reports")
+      testOptions += Tests.Argument(TestFrameworks.ScalaTest, "-oDF", "-u", "target/test-reports")
     )
 
     def coverageSettings(excludedPackages: String = "", minimumCoverage: Double = 80.00, failOnMinimum: Boolean = true): Def.SettingsDefinition = {


### PR DESCRIPTION
In sbt 1.5.x the default `IntegrationTest` Configuration uses `it-reports` (e.g. `core_utils_spark_apps/target/it-reports`) (https://jenkins.dot-data.net/blue/organizations/jenkins/e2e%2Fdocker_tests_dev/detail/docker_tests_dev/1023/pipeline)

Setting this to not be only the `Test` scope, since all of our jenkins jobs look for them in `test-reports`

