### PR TITLE
SA-51241: Use common Databricks shading config conditionally in all projects (part 1)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -51,6 +51,7 @@ addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0")
 // Currently sbt-scoverage doesn't work for scala 2.12.13:
 //   - https://github.com/scoverage/sbt-scoverage/issues/321
 addSbtPlugin("org.scoverage"  %% "sbt-scoverage"         % "1.6.1")
+addSbtPlugin("com.eed3si9n"   % "sbt-assembly"           % "0.14.10")
 
 // Make the build faster, since there is no Scaladocs anyway
 sources in (Compile, doc) := Seq.empty

--- a/src/main/scala/com/dotdata/sbt/SbtConfigPlugin.scala
+++ b/src/main/scala/com/dotdata/sbt/SbtConfigPlugin.scala
@@ -2,6 +2,7 @@ package com.dotdata.sbt
 
 import org.scalafmt.sbt.ScalafmtPlugin.autoImport._
 import org.scalastyle.sbt.ScalastylePlugin.autoImport._
+import sbtassembly.ShadeRule
 import scoverage.ScoverageKeys._
 import sbt.Keys._
 import sbt._
@@ -302,6 +303,15 @@ object SbtConfigPlugin extends AutoPlugin {
 
         githubVersion.getOrElse(localDevVersion)
       }
+    }
+
+    def DatabricksAssemblyShadeRules: Seq[ShadeRule] = sys.env.get("BUILD_FOR_DATABRICKS") match {
+      case Some(buildForDatabricks) if Seq("true", "enabled").contains(buildForDatabricks) =>
+        Seq(
+          ShadeRule.rename("com.typesafe.config.**" -> "shadeio.config.@1").inAll,
+          ShadeRule.rename("cats.**" -> "shadeio.cats.@1").inAll
+        )
+      case _ => Seq.empty
     }
   }
 


### PR DESCRIPTION
Databricks Runtimes include their own versions of libraries (see https://docs.databricks.com/release-notes/runtime/7.6.html). To use `script_api` in Databricks, we need to shade Typesafe Config and Cats in several `bigdata` projects. This PR introduces the common shading configuration. 

See https://github.com/ramencloud/bigdata/pull/25804 for an example of usage.