### PR TITLE
Add shading setting

### DIFF
--- a/src/main/scala/com/dotdata/sbt/SbtConfigPlugin.scala
+++ b/src/main/scala/com/dotdata/sbt/SbtConfigPlugin.scala
@@ -11,7 +11,6 @@ import software.amazon.awssdk.auth.credentials.{AwsCredentials, DefaultCredentia
 import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.services.codeartifact.CodeartifactClient
 import software.amazon.awssdk.services.codeartifact.model.{GetAuthorizationTokenRequest, PackageFormat, PackageVersionStatus, UpdatePackageVersionsStatusRequest}
-import com.eed3si9n.jarjarabrams.{ ShadeRule => JJAShadeRule }
 
 import scala.collection.JavaConverters._
 
@@ -410,6 +409,7 @@ object SbtConfigPlugin extends AutoPlugin {
 
           settings ++ (Compile +: testConfigurations).flatMap(inConfig(_)(settings))
         }
+
         val assemblySettings = Seq(
           assembleArtifact := true,
           assembly / assemblyOption ~= {

--- a/src/main/scala/com/dotdata/sbt/SbtConfigPlugin.scala
+++ b/src/main/scala/com/dotdata/sbt/SbtConfigPlugin.scala
@@ -11,6 +11,7 @@ import software.amazon.awssdk.auth.credentials.{AwsCredentials, DefaultCredentia
 import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.services.codeartifact.CodeartifactClient
 import software.amazon.awssdk.services.codeartifact.model.{GetAuthorizationTokenRequest, PackageFormat, PackageVersionStatus, UpdatePackageVersionsStatusRequest}
+import com.eed3si9n.jarjarabrams.{ ShadeRule => JJAShadeRule }
 
 import scala.collection.JavaConverters._
 
@@ -497,6 +498,11 @@ object SbtConfigPlugin extends AutoPlugin {
         githubVersion.getOrElse(localDevVersion)
       }
     }
+
+    def assemblyShadeRules: Seq[JJAShadeRule] = Seq(
+        ShadeRule.rename("com.typesafe.config.**" -> "shadeio.config.@1").inAll,
+        ShadeRule.rename("cats.**" -> "shadeio.cats.@1").inAll
+    )
   }
 
 }

--- a/src/main/scala/com/dotdata/sbt/SbtConfigPlugin.scala
+++ b/src/main/scala/com/dotdata/sbt/SbtConfigPlugin.scala
@@ -410,7 +410,6 @@ object SbtConfigPlugin extends AutoPlugin {
 
           settings ++ (Compile +: testConfigurations).flatMap(inConfig(_)(settings))
         }
-
         val assemblySettings = Seq(
           assembleArtifact := true,
           assembly / assemblyOption ~= {
@@ -418,6 +417,11 @@ object SbtConfigPlugin extends AutoPlugin {
               .withIncludeBin(includeBin)
               .withIncludeDependency(includeDependency)
           },
+          assembly / assemblyShadeRules := Seq(
+            ShadeRule.rename("com.typesafe.config.**" -> "shadeio.config.@1").inAll,
+            ShadeRule.rename("cats.**" -> "shadeio.cats.@1").inAll,
+            ShadeRule.rename("shapeless.**" -> "shadeio.shapeless.@1").inAll
+          ),
           assembly / assemblyMergeStrategy := {
             case "scalafmt.conf" => MergeStrategy.discard
             case "scalastyle-config.xml" => MergeStrategy.discard
@@ -498,11 +502,6 @@ object SbtConfigPlugin extends AutoPlugin {
         githubVersion.getOrElse(localDevVersion)
       }
     }
-
-    def assemblyShadeRules: Seq[JJAShadeRule] = Seq(
-        ShadeRule.rename("com.typesafe.config.**" -> "shadeio.config.@1").inAll,
-        ShadeRule.rename("cats.**" -> "shadeio.cats.@1").inAll
-    )
   }
 
 }


### PR DESCRIPTION
On the occasion of core repo separation, we agreed to add the shading globally. The PR adds the shading setting based on the file. ( https://github.com/ramencloud/sbt-databricks/blob/main/src/main/scala/com/dotdata/sbt/SbtDatabricksPlugin.scala )

After we merge the PR, we can remove the reference to the repo from the core and bigdata repo and delete the repo itself.
https://github.com/ramencloud/sbt-databricks

