### PR TITLE
Remove the -u flag from ScalaTest testOptions

### DIFF
--- a/src/main/scala/com/dotdata/sbt/SbtConfigPlugin.scala
+++ b/src/main/scala/com/dotdata/sbt/SbtConfigPlugin.scala
@@ -280,8 +280,9 @@ object SbtConfigPlugin extends AutoPlugin {
       //  - -o: output to stdout (default, but required for other flags)
       //  - D: Show durations of each test
       //  - F: Show full stack traces
-      //  - -u: Causes test results to be written to junit-style xml files in the named directory so CI can pick it up
-      testOptions += Tests.Argument(TestFrameworks.ScalaTest, "-oDF", "-u", "target/test-reports")
+      // Note: the "-u" flag for writing JUnit XMLs is not used since it conflicts
+      // with the JUnitXmlReportPlugin built into SBT in recent versions
+      testOptions += Tests.Argument(TestFrameworks.ScalaTest, "-oDF")
     )
 
     def coverageSettings(excludedPackages: String = "", minimumCoverage: Double = 80.00, failOnMinimum: Boolean = true): Def.SettingsDefinition = {


### PR DESCRIPTION
SA-51408

The "-u" flag, followed by a directory, instructed ScalaTest to report
test results in the specified directory.  However, newer versions of SBT
automatically enable a built-in `JUnitXmlReportPlugin` which write the
same reports.  These reporters can conflict with each other, with each
trying to append to the same file concurrently and producing invalid
data.

Either the built-in plugin could be disabled or the flag removed from
the ScalaTest `testOptions` setting in order to remove the conflict.  This
commit removes the ScalaTest version since that can be specified within
this plugin rather than in the destination project, and it represents
fewer deviations from the default settings overall.